### PR TITLE
Update input_module_github_api_repos_commits.py - api url change

### DIFF
--- a/bin/input_module_github_api_repos_commits.py
+++ b/bin/input_module_github_api_repos_commits.py
@@ -54,7 +54,7 @@ def collect_events(helper, ew):
     parameter = {}
     parameter['since'] = last_status
     parameter['per_page'] = git_pagesize
-    url = "https://{0}/api/v3/repos/{1}/{2}/commits".format(git_instance,git_owner,git_repo)
+    url = "https://{0}/repos/{1}/{2}/commits".format(git_instance,git_owner,git_repo)
     method = 'GET'
     
     try:


### PR DESCRIPTION
Fixes #1
- removed api version specification
Reason - by default, all requests to https://api.github.com receive the v3 version of the REST API.  I have no idea why specifying version actually breaks it.  REF:  https://developer.github.com/v3